### PR TITLE
Added new call `getKeysThatStartWithPrefix`.

### DIFF
--- a/src/AsyncStorage.native.ts
+++ b/src/AsyncStorage.native.ts
@@ -176,6 +176,28 @@ const AsyncStorage = ((): AsyncStorageStatic => {
     },
 
     /**
+     * Gets keys that start with the supplied prefix.
+     * This will include any keys known to your app; for all callers, libraries, etc.
+     *
+     */
+    getKeysThatStartWithPrefix: (prefix: string, callback) => {
+      return new Promise((resolve, reject) => {
+        RCTAsyncStorage.getKeysThatStartWithPrefix(
+          prefix,
+          (error?: ErrorLike, keys?: string[]) => {
+            const err = convertError(error);
+            callback?.(err, keys);
+            if (keys) {
+              resolve(keys);
+            } else {
+              reject(err);
+            }
+          }
+        );
+      });
+    },
+
+    /**
      * The following batched functions are useful for executing a lot of
      * operations at once, allowing for native optimizations and provide the
      * convenience of a single callback after all operations are complete.

--- a/src/AsyncStorage.ts
+++ b/src/AsyncStorage.ts
@@ -120,6 +120,29 @@ const AsyncStorage: AsyncStorageStatic = {
   },
 
   /**
+   * Gets keys that start with the supplied prefix.
+   * This will include any keys known to your app; for all callers, libraries, etc.
+   *
+   */
+  getKeysThatStartWithPrefix: (prefix: string, callback) => {
+    return createPromise(() => {
+      if (!prefix) {
+        return [] as string[];
+      }
+
+      const numberOfKeys = window.localStorage.length;
+      const keys: string[] = [];
+      for (let i = 0; i < numberOfKeys; i += 1) {
+        const key = window.localStorage.key(i) || '';
+        if (key.startsWith(prefix)) {
+          keys.push(key);
+        }
+      }
+      return keys;
+    }, callback);
+  },
+
+  /**
    * (stub) Flushes any pending requests using a single batch call to get the data.
    */
   flushGetRequests: () => undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,16 @@ export type AsyncStorageStatic = {
   ) => Promise<readonly string[]>;
 
   /**
+   * Gets keys that start with the supplied prefix.
+   * This will include any keys known to your app; for all callers, libraries, etc.
+   *
+   */
+  getKeysThatStartWithPrefix: (
+    prefix: string,
+    callback?: CallbackWithResult<readonly string[]>
+  ) => Promise<readonly string[]>;
+
+  /**
    * The following batched functions are useful for executing a lot of
    * operations at once, allowing for native optimizations and provide the
    * convenience of a single callback after all operations are complete.

--- a/windows/code/DBStorage.h
+++ b/windows/code/DBStorage.h
@@ -117,6 +117,7 @@ struct DBStorage {
                                        const std::vector<KeyValue> &keyValues) noexcept;
         std::optional<bool> MultiRemove(sqlite3 *db, const std::vector<std::string> &keys) noexcept;
         std::optional<std::vector<std::string>> GetAllKeys(sqlite3 *db) noexcept;
+        std::optional<std::vector<std::string>> GetKeysThatStartWithPrefix(sqlite3 *db, const std::string &prefix) noexcept;
         std::optional<bool> RemoveAll(sqlite3 *db) noexcept;
 
     private:


### PR DESCRIPTION
This is used to get keys that start with the supplied prefix.

NOTE: Only localstorage and Windows implementation have this new function. iOS, Android, and macOS still need it implemented.

